### PR TITLE
fix double charge in _postSell

### DIFF
--- a/src/Maelstrom.sol
+++ b/src/Maelstrom.sol
@@ -171,9 +171,7 @@ contract Maelstrom {
         require((ethBalance[token] * 10) / 100 >= amountEther, "Not more than 10% of eth in pool can be used for swap");
         ethBalance[token] -= amountEther;
         uint256 totalFee = ((pools[token].finalSellPrice - sellPrice) * amountToken) / 1e18;
-
         if (totalFee != 0) processProtocolFees(token, totalFee);
-
         updatePriceSellParams(token, amountToken, sellPrice);
         return (amountEther, sellPrice);
     }


### PR DESCRIPTION
**fixed code for the _postSell function in src/Maelstrom.sol. The second duplicate call to processProtocolFees has been removed to prevent double-charging fees.**
@kaneki003 @DengreSarthak 
Closes #6 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where protocol fees could be incorrectly charged multiple times during sell transactions, ensuring accurate fee calculation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->