### PR TITLE
Add remapping for OpenZeppelin contracts

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,7 +7,8 @@ optimizer_runs = 200
 via_ir = true
 remappings = [
     "openzeppelin-contracts/=lib/openzeppelin-contracts/",
-    "prb-math/=lib/prb-math/"
+    "prb-math/=lib/prb-math/",
+    "node_modules/openzeppelin/=@openzeppelin/contracts/"
 ]
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options


### PR DESCRIPTION
Issue: Path Resolution Mismatch

Fix: Add node_modules/openzeppelin/=@openzeppelin/contracts/ to the remappings array in the foundry.toml file.

Closes #16 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module dependency mappings to include support for OpenZeppelin contracts, enhancing library resolution configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->