### PR TITLE
Fix Exponential Decay Calculation in _getDecayValue Function

### DIFF
--- a/src/Maelstrom.sol
+++ b/src/Maelstrom.sol
@@ -127,7 +127,7 @@ contract Maelstrom {
     }
 
     function _getDecayValue(uint256 initialVolume, int256 timeElapsed) internal pure returns (uint256) {
-        int256 decayedAmount = SD59x18.unwrap(SD59x18.wrap((int256)(initialVolume)) * exp(SD59x18.wrap(-timeElapsed)));
+        int256 decayedAmount = SD59x18.unwrap(SD59x18.wrap((int256)(initialVolume)) * exp(SD59x18.wrap(-timeElapsed * 1e18)));
         return (uint256)(decayedAmount);
     }
 


### PR DESCRIPTION
Fixes #37 

Pull Request Description:
This PR addresses Critical Issue 1 identified in the Maelstrom contract, where the _getDecayValue function incorrectly handled the timeElapsed parameter when using the prb-math library for exponential decay calculations.

Problem:
The timeElapsed parameter was passed as a raw integer to the SD59x18.wrap function, which expects values in fixed-point format (where 1 is represented as 10^18). This caused the decay calculation to always return 1, effectively disabling the intended decay mechanism.

Fix:
- Scaled timeElapsed by 1e18 before wrapping it into the fixed-point format.
- Updated the _getDecayValue function to ensure proper exponential decay behavior.

Code Changes:
```
// Before
int256 decayedAmount = SD59x18.unwrap(SD59x18.wrap((int256)(initialVolume)) * exp(SD59x18.wrap(-timeElapsed)));

// After
int256 decayedAmount = SD59x18.unwrap(SD59x18.wrap((int256)(initialVolume)) * exp(SD59x18.wrap(-timeElapsed * 1e18)));
```

Impact:
- Ensures that the decay mechanism works as intended, allowing prices and volumes to stabilize over time.
- Fixes a critical logic bug that could have led to incorrect protocol behavior.

Testing:
- Verified that the updated _getDecayValue function produces the expected results for various timeElapsed values.
- Ensured no other parts of the contract were affected by this change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined internal decay calculation mechanism for improved precision in value degradation computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->