### PR TITLE
fix: prevent treasury revert DoS by storing pending fees

### DIFF
--- a/src/Maelstrom.sol
+++ b/src/Maelstrom.sol
@@ -35,6 +35,8 @@ contract Maelstrom {
     event SwapTrade(address indexed tokenSold, address indexed tokenBought, address indexed trader, uint256 amountTokenSold, uint256 amountTokenBought, uint256 tradeSellPrice, uint256 updatedSellPrice, uint256 tradeBuyPrice, uint256 updatedBuyPrice);
     event Deposit(address indexed token, address indexed user, uint256 amountEther, uint256 amountToken, uint256 lpTokensMinted);
     event Withdraw(address indexed token, address indexed user, uint256 amountEther, uint256 amountToken, uint256 lpTokensBurned);
+    event FeeTransferFailed(address indexed treasury, uint256 amount);
+    event FeePending(address indexed treasury, uint256 amount);
     uint256 public auctionResetPercentage = 5;
     uint256 public totalFees = 0;
     address[] public poolList;
@@ -45,6 +47,7 @@ contract Maelstrom {
     mapping(address => LiquidityPoolToken) public poolToken;
     mapping(address => uint256) public ethBalance;
     mapping(address => PoolParams) public pools;
+    mapping(address => uint256) public pendingFees;
     ProtocolParameters protocolParameters;
 
     modifier validAmount(uint256 amount) {
@@ -139,7 +142,26 @@ contract Maelstrom {
         uint256 stableFees = (totalFee * protocolParameters.fee()) / 10000;
         address feeRecipient = protocolParameters.treasury();
         (bool success, ) = feeRecipient.call{ value: stableFees }("");
-        require(success, "Transfer failed");
+        if (!success) {
+            pendingFees[feeRecipient] += stableFees;
+            emit FeePending(feeRecipient, stableFees);
+        }
+    }
+
+    function withdrawPendingFees() external {
+        address feeRecipient = protocolParameters.treasury();
+        uint256 amount = pendingFees[feeRecipient];
+        require(amount > 0, "No pending fees");
+        pendingFees[feeRecipient] = 0;
+        (bool success, ) = feeRecipient.call{ value: amount }("");
+        if (!success) {
+            pendingFees[feeRecipient] = amount;
+            emit FeeTransferFailed(feeRecipient, amount);
+        }
+    }
+
+    function getPendingFees(address treasuryAddress) external view returns (uint256) {
+        return pendingFees[treasuryAddress];
     }
 
     function updatePriceSellParams(address token, uint256 amountToken, uint256 newPrice) internal {


### PR DESCRIPTION
## Summary
Prevents the Treasury Revert Denial of Service (DoS) vulnerability (#44) by modifying the `processProtocolFees` function to not revert when ETH transfer to treasury fails. Instead, failed fees are stored in a `pendingFees` mapping for later withdrawal.

## Changes
- Modified `processProtocolFees` to store fees as pending instead of reverting on failed transfer
- Added `pendingFees` mapping to track accumulated pending fees
- Added `withdrawPendingFees()` function for treasury to withdraw accumulated fees
- Added `getPendingFees()` view function to check pending fees
- Added `FeePending` and `FeeTransferFailed` events for tracking

## Why This Fix Works
The protocol previously required ETH transfer success to treasury during every trade. If the treasury (which may be a smart contract) cannot receive ETH (e.g., no receive() function, reverts unexpectedly, or runs out of gas), all trading would stop. This fix ensures trading continues even if treasury is temporarily unable to receive fees.

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability for treasuries to withdraw accumulated pending fees.
  * Added view function to check pending fee balances.

* **Bug Fixes**
  * Improved fee transfer resilience—failed ETH transfers no longer revert the transaction but instead credit the amount for later withdrawal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->